### PR TITLE
Add C interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ benchmark/spreadtestnd_mel
 benchmark/nfft_simpletest
 benchmark/result/*.out
 *.o
+
+lib
+lib-static

--- a/makefile
+++ b/makefile
@@ -32,6 +32,9 @@ LIBNAME=libcufinufft$(PRECSUFFIX)
 DYNAMICLIB=lib/$(LIBNAME).so
 STATICLIB=lib-static/$(LIBNAME).a
 
+CLIBNAME=libcufinufftc$(PRECSUFFIX)
+DYNAMICCLIB=lib/$(CLIBNAME).so
+
 HEADERS = src/cufinufft.h src/deconvolve.h src/memtrasfer.h src/profile.h \
 	src/spreadinterp.h
 FINUFFTOBJS=finufft/utils.o finufft/dirft2d.o finufft/common.o \
@@ -44,6 +47,7 @@ CUFINUFFTOBJS=src/2d/spreadinterp2d.o src/2d/cufinufft2d.o \
 	src/3d/spreadinterp3d.o src/3d/spread3d_wrapper.o \
 	src/3d/interp3d_wrapper.o src/3d/cufinufft3d.o
 	
+CUFINUFFTCOBJS=src/cufinufftc.o
 #-include make.inc
 
 %.o: %.cpp
@@ -101,12 +105,18 @@ cufinufft3d2_test: test/cufinufft3d2_test.o $(CUFINUFFTOBJS) $(FINUFFTOBJS)
 
 lib: $(STATICLIB) $(DYNAMICLIB)
 
+clib: $(DYNAMICCLIB)
+
 $(STATICLIB): $(CUFINUFFTOBJS) $(FINUFFTOBJS)
 	mkdir -p lib-static
 	ar rcs $(STATICLIB) $(CUFINUFFTOBJS) $(FINUFFTOBJS)
 $(DYNAMICLIB): $(CUFINUFFTOBJS) $(FINUFFTOBJS)
 	mkdir -p lib	
 	$(NVCC) -shared $(NVCCFLAGS) $(CUFINUFFTOBJS) $(FINUFFTOBJS) -o $(DYNAMICLIB) $(LIBS) 
+
+$(DYNAMICCLIB): $(CUFINUFFTCOBJS) $(STATICLIB)
+	mkdir -p lib
+	gcc -shared -o $(DYNAMICCLIB) $(CUFINUFFTCOBJS) $(STATICLIB) $(LIBS)
 
 all: spread2d interp2d spreadinterp_test finufft2d_test cufinufft2d1_test \
 	cufinufft2d2_test cufinufft2d1many_test cufinufft2d2many_test spread3d \

--- a/src/cufinufftc.cpp
+++ b/src/cufinufftc.cpp
@@ -1,0 +1,32 @@
+#include "cufinufft.h"
+
+extern "C" {
+
+int cufinufftc_default_opts(finufft_type type, int dim, nufft_opts *opts)
+{
+    return cufinufft_default_opts(type, dim, *opts);
+}
+
+int cufinufftc_makeplan(finufft_type type, int dim, int *n_modes, int iflag,
+    int ntransf, FLT tol, int ntransfcufftplan, cufinufft_plan *d_plan)
+{
+    return cufinufft_makeplan(type, dim, n_modes, iflag, ntransf, tol, ntransfcufftplan, d_plan);
+}
+
+int cufinufftc_setNUpts(int M, FLT* h_kx, FLT* h_ky, FLT* h_kz, int N, FLT
+        *h_s, FLT *h_t, FLT *h_u, cufinufft_plan *d_plan)
+{
+    return cufinufft_setNUpts(M, h_kx, h_ky, h_kz, N, h_s, h_t, h_u, d_plan);
+}
+
+int cufinufftc_exec(CUCPX* h_c, CUCPX* h_fk, cufinufft_plan *d_plan)
+{
+    return cufinufft_exec(h_c, h_fk, d_plan);
+}
+
+int cufinufftc_destroy(cufinufft_plan *d_plan)
+{
+    return cufinufft_destroy(d_plan);
+}
+
+}


### PR DESCRIPTION
This PR adds a C interface that can be compiled using `make clib`. It essentially wraps the C++ interface and translates pointers to references when necessary. The functions have the same name except that the prefix is changed from `cufinufft_` to `cufinufftc_`.

Going forward, it would be better to have a single C interface, called from both C and C++, like FINUFFT does. For now, however, this gives us a simple way to interact with the library from `ctypes`.