### PR TITLE
Add Python interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ benchmark/spreadtestnd_mel
 benchmark/nfft_simpletest
 benchmark/result/*.out
 *.o
+
+__pycache__

--- a/python/cufinufft.py
+++ b/python/cufinufft.py
@@ -1,0 +1,178 @@
+import ctypes
+
+import numpy as np
+import pycuda.driver as cuda
+
+c_int = ctypes.c_int
+c_uint = ctypes.c_uint
+c_float = ctypes.c_float
+
+c_void_p = ctypes.c_void_p
+c_int_p = ctypes.POINTER(c_int)
+c_float_p = ctypes.POINTER(c_float)
+
+class NufftOpts(ctypes.Structure): pass
+NufftOpts._fields_ = [
+    ('debug', c_int),
+    ('spread_debug', c_int),
+    ('spread_sort', c_int),
+    ('spread_kerevalmeth', c_int),
+    ('spread_kerpad', c_int),
+    ('chkbnds', c_int),
+    ('fftw', c_int),
+    ('modeord', c_int),
+    ('upsampfac', c_float),
+    ('gpu_method', c_int),
+    ('gpu_sort', c_int),
+    ('gpu_binsizex', c_int),
+    ('gpu_binsizey', c_int),
+    ('gpu_binsizez', c_int),
+    ('gpu_obinsizex', c_int),
+    ('gpu_obinsizey', c_int),
+    ('gpu_obinsizez', c_int),
+    ('gpu_maxsubprobsize', c_int),
+    ('gpu_nstreams', c_int),
+    ('gpu_kerevalmeth', c_int)]
+
+class SpreadOpts(ctypes.Structure): pass
+SpreadOpts._fields_ = [
+    ('nspread', c_int),
+    ('spread_direction', c_int),
+    ('pirange', c_int),
+    ('chkbnds', c_int),
+    ('sort', c_int),
+    ('kerevalmeth', c_int),
+    ('kerpad', c_int),
+    ('sort_threads', c_int),
+    ('max_subproblem_size', c_int),
+    ('flags', c_int),
+    ('debug', c_int),
+    ('upsampfac', c_float),
+    ('ES_beta', c_float),
+    ('ES_halfwidth', c_float),
+    ('ES_c', c_float)]
+
+class CufinufftPlan(ctypes.Structure): pass
+CufinufftPlan._fields_ = [
+    ('type', c_uint),
+    ('opts', NufftOpts),
+    ('spopts', SpreadOpts),
+    ('dim', c_int),
+    ('M', c_int),
+    ('nf1', c_int),
+    ('nf2', c_int),
+    ('nf3', c_int),
+    ('ms', c_int),
+    ('mt', c_int),
+    ('mu', c_int),
+    ('ntransf', c_int),
+    ('ntransfcufftplan', c_int),
+    ('iflag', c_int),
+    ('totalnumsubprob', c_int),
+    ('byte_now', c_int),
+    ('fwkerhalf1', c_float_p),
+    ('fwkerhalf2', c_float_p),
+    ('fwkerhalf3', c_float_p),
+    ('kx', c_float_p),
+    ('ky', c_float_p),
+    ('kz', c_float_p),
+    ('c', c_void_p),
+    ('fw', c_void_p),
+    ('fk', c_void_p),
+    ('idxnupts', c_int_p),
+    ('sortidx', c_int_p),
+    ('numsubprob', c_int_p),
+    ('binsize', c_int_p),
+    ('binstartpts', c_int_p),
+    ('subprob_to_bin', c_int_p),
+    ('subprobstartpts', c_int_p),
+    ('finegridsize', c_int_p),
+    ('fgstartpts', c_int_p),
+    ('numnupts', c_int_p),
+    ('subprob_to_nupts', c_int_p),
+    ('fftplan', c_int),
+    ('streams', c_void_p)]
+
+CufinufftPlan_p = ctypes.POINTER(CufinufftPlan)
+NufftOpts_p = ctypes.POINTER(NufftOpts)
+
+lib = ctypes.cdll.LoadLibrary('../lib/libcufinufftcf.so')
+
+_default_opts = lib.cufinufftc_default_opts
+_default_opts.argtypes = [c_uint, c_int, NufftOpts_p]
+_default_opts.restype = c_int
+
+
+def default_opts(finufft_type, dim):
+    nufft_opts = NufftOpts()
+
+    ier = _default_opts(finufft_type - 1, dim, nufft_opts)
+
+    if ier != 0:
+        raise RuntimeError('Configuration not yet implemented.')
+
+    return nufft_opts
+
+_make_plan = lib.cufinufftc_makeplan
+_make_plan.argtypes = [
+    c_uint, c_int, c_int_p, c_int,
+    c_int, c_float, c_int, CufinufftPlan_p]
+_make_plan.restypes = c_int
+
+def plan(finufft_type, modes, isign, tol, opts=None):
+    dim = len(modes)
+
+    if opts is None:
+        opts = default_opts(finufft_type, dim)
+
+    modes = modes + (1,) * (3 - dim)
+    modes = (c_int * 3)(*modes)
+
+    plan = CufinufftPlan()
+    plan.opts = opts
+
+    ier = _make_plan(finufft_type - 1, dim, modes, isign, 1, float(tol), 1, plan)
+
+    if ier != 0:
+        raise RuntimeError('Error creating plan.')
+
+    return plan
+
+_set_nu_pts = lib.cufinufftc_setNUpts
+_set_nu_pts.argtypes = [
+    c_int, c_void_p, c_void_p, c_void_p, ctypes.c_int, c_float_p,
+    c_float_p, c_float_p, CufinufftPlan_p]
+_set_nu_pts.restype = c_int
+
+def set_nu_pts(plan, M, kx, ky=None, kz=None):
+    if ky is None: ky = 0
+    if kz is None: kz = 0
+
+    ier = _set_nu_pts(M, int(kx), int(ky), int(kz), 0, None, None, None, plan)
+
+    if ier != 0:
+        raise RuntimeError('Error setting non-uniform points.')
+
+_exec_plan = lib.cufinufftc_exec
+_exec_plan.argtypes = [c_void_p, c_void_p, CufinufftPlan_p]
+_exec_plan.restype = c_int
+
+def execute(plan, c, fk):
+    ier = _exec_plan(int(c), int(fk), plan)
+
+    if ier != 0:
+        raise RuntimeError('Error executing plan.')
+
+_destroy_plan = lib.cufinufftc_destroy
+_destroy_plan.argtypes = [CufinufftPlan_p]
+_destroy_plan.restype = c_int
+
+def destroy(plan):
+    ier = _destroy_plan(plan)
+
+    if ier != 0:
+        raise RuntimeError('Error destroying plan.')
+
+
+__all__ = ['CufinufftPlan', 'NufftOpts', 'SpreadOpts', 'default_opts',
+        'make_plan', 'set_nu_pts', 'exec_plan', 'destroy_plan']

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,3 @@
+cython
+numpy
+pycuda

--- a/python/test.py
+++ b/python/test.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+import pycuda.autoinit
+import pycuda.driver as cuda
+import pycuda.gpuarray as gpuarray
+
+import cufinufft
+
+import utils
+
+
+def test_type1(shape=(16, 16, 16), M=4096, tol=1e-3):
+    kxyz = utils.gen_nu_pts(M)
+    c = utils.gen_nonuniform_data(M)
+
+    kxyz_gpu = gpuarray.to_gpu(kxyz)
+    c_gpu = gpuarray.to_gpu(c)
+    fk_gpu = gpuarray.GPUArray(shape, dtype=np.complex64)
+
+    plan = cufinufft.plan(1, shape, 1, tol)
+
+    cufinufft.set_nu_pts(plan, M, kxyz_gpu[0].gpudata, kxyz_gpu[1].gpudata,
+            kxyz_gpu[2].gpudata)
+
+    cufinufft.execute(plan, c_gpu.gpudata, fk_gpu.gpudata)
+
+    fk = fk_gpu.get()
+
+    ind = int(0.1789 * np.prod(shape))
+
+    fk_est = fk.ravel()[ind]
+    fk_target = utils.direct_type1(c, kxyz, shape, ind)
+
+    type1_rel_err = np.abs(fk_target - fk_est) / np.abs(fk_target)
+
+    print('Type 1 relative error:', type1_rel_err)
+
+
+def test_type2(shape=(16, 16, 16), M=4096, tol=1e-3):
+    kxyz = utils.gen_nu_pts(M)
+    fk = utils.gen_uniform_data(shape)
+
+    kxyz_gpu = gpuarray.to_gpu(kxyz)
+    fk_gpu = gpuarray.to_gpu(fk)
+
+    c_gpu = gpuarray.GPUArray(shape=(M,), dtype=np.complex64)
+
+    plan = cufinufft.plan(2, shape, -1, tol)
+
+    cufinufft.set_nu_pts(plan, M, kxyz_gpu[0].gpudata, kxyz_gpu[1].gpudata,
+            kxyz_gpu[2].gpudata)
+
+    cufinufft.execute(plan, c_gpu.gpudata, fk_gpu.gpudata)
+
+    cufinufft.destroy(plan)
+
+    c = c_gpu.get()
+
+    ind = M // 2
+
+    c_est = c[ind]
+    c_target = utils.direct_type2(fk, kxyz[:, ind])
+
+    type2_rel_err = np.abs(c_target - c_est) / np.abs(c_target)
+
+    print('Type 2 relative error:', type2_rel_err)
+
+
+def main():
+    test_type1()
+    test_type2()
+
+
+if __name__ == '__main__':
+    main()

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+def gen_nu_pts(M, seed=0):
+    rng = np.random.default_rng(seed)
+    kxyz = rng.uniform(-np.pi, np.pi, (3, M))
+    kxyz = kxyz.astype(np.float32)
+    return kxyz
+
+
+def gen_uniform_data(shape, seed=0):
+    rng = np.random.default_rng(seed)
+    fk = rng.standard_normal(shape + (2,))
+    fk = fk.astype(np.float32).view(np.complex64)[..., 0]
+    return fk
+
+
+def gen_nonuniform_data(M, seed=0):
+    rng = np.random.default_rng(seed)
+    c = rng.standard_normal(2 * M)
+    c = c.astype(np.float32).view(np.complex64)
+    return c
+
+
+def make_grid(shape):
+    dim = len(shape)
+    shape = (1,) * (3 - dim) + shape
+
+    grids = [np.arange(-(N // 2), (N + 1) // 2) for N in shape]
+    z, y, x = np.meshgrid(*grids, indexing='ij')
+    return np.stack((x, y, z))
+
+
+def direct_type1(c, kxyz, shape, ind):
+    xyz = make_grid(shape)
+
+    phase = kxyz.T @ xyz.reshape((3, -1))[:, ind]
+    fk = np.sum(c * np.exp(1j * phase))
+
+    return fk
+
+
+def direct_type2(fk, kxyz):
+    xyz = make_grid(fk.shape)
+
+    phase = kxyz @ xyz.reshape((3, -1))
+    c = np.sum(fk.ravel() * np.exp(-1j * phase))
+
+    return c


### PR DESCRIPTION
This PR adds a simple Python interface using `ctypes` along with a small driver. It depends on the C interface being present, so please merge #2 before merging this one. Documentation and basic error checks are still missing, but these will be added in a future PR.